### PR TITLE
fix: derive Jason.Encoder for embedded translation resources

### DIFF
--- a/lib/resource/transformers/create_translation_resource.ex
+++ b/lib/resource/transformers/create_translation_resource.ex
@@ -34,6 +34,7 @@ defmodule AshTranslation.Resource.Transformers.CreateTranslationResource do
     Module.create(
       module_name,
       quote location: :keep do
+        @derive {Jason.Encoder, except: [:__meta__]}
         use Ash.Resource, data_layer: :embedded
 
         attributes do
@@ -55,6 +56,7 @@ defmodule AshTranslation.Resource.Transformers.CreateTranslationResource do
     Module.create(
       module_name,
       quote location: :keep do
+        @derive {Jason.Encoder, except: [:__meta__]}
         use Ash.Resource, data_layer: :embedded
 
         attributes do


### PR DESCRIPTION
## Problem

When using AshTranslation with AshPostgres.DataLayer, updating a resource that has translations fails with:

` (Protocol.UndefinedError) protocol Jason.Encoder not implemented for MyApp.Post.Translations (a struct)`

This happens because the dynamically created Translations and Translations.Fields embedded modules don't implement Jason.Encoder. Postgres needs to serialize these structs to JSON for storage in a jsonb column.


## How to reproduce
```elixir
defmodule MyApp.Post do
  use Ash.Resource,
    domain: MyApp.Domain,
    data_layer: AshPostgres.DataLayer,
    extensions: [AshTranslation.Resource]

  postgres do
    table "posts"
    repo MyApp.Repo
  end

  actions do
    defaults [:create, :read, :update, :destroy]
    default_accept :*
  end

  translations do
    public? true
    fields [:title]
    locales [:fr]
  end

  attributes do
    uuid_primary_key :id
    attribute :title, :string, public?: true
  end
end

# This fails:
post = Ash.create!(MyApp.Post, %{title: "Hello"})
Ash.update!(post, %{translations: %{fr: %{title: "Bonjour"}}})
```

## Fix

Added `@derive {Jason.Encoder, except: [:__meta__]}` to both dynamically created modules (`Translations` and `Translations.Fields`) in the transformer, before the `use Ash.Resource` call.